### PR TITLE
feat: add update frequency and operation mode parameters to MQTT client

### DIFF
--- a/victron_vrm/client.py
+++ b/victron_vrm/client.py
@@ -511,7 +511,7 @@ class VictronVRMClient:
 
         Args:
             installation_id: Installation ID
-            update_frequency: Update frequency in seconds (0-300)
+            update_frequency: Update frequency in seconds (0-3600)
             operation_mode: Operation mode for the MQTT client
 
         Returns:
@@ -546,4 +546,6 @@ class VictronVRMClient:
             username=mqtt_username,
             password=mqtt_password,
             vrm_id=installation.identifier,
+            update_frequency=update_frequency,
+            operation_mode=operation_mode,
         )

--- a/victron_vrm/client.py
+++ b/victron_vrm/client.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional, Literal
 
 import aiohttp
 from pydantic import ValidationError
+from victron_mqtt import OperationMode
 
 from victron_vrm.mqtt import VRMMQTTClient
 
@@ -503,11 +504,15 @@ class VictronVRMClient:
     async def get_mqtt_client_for_installation(
         self,
         installation_id: int,
+        update_frequency: int | None = None,
+        operation_mode: OperationMode = OperationMode.FULL,
     ) -> "VRMMQTTClient":
         """Get an MQTT client for the specified installation.
 
         Args:
             installation_id: Installation ID
+            update_frequency: Update frequency in seconds (0-300)
+            operation_mode: Operation mode for the MQTT client
 
         Returns:
             VRMMQTTClient: MQTT client for the installation

--- a/victron_vrm/mqtt.py
+++ b/victron_vrm/mqtt.py
@@ -1,4 +1,4 @@
-from victron_mqtt import Hub as VictronMQTTHub
+from victron_mqtt import Hub as VictronMQTTHub, OperationMode
 
 
 class VRMMQTTClient(VictronMQTTHub):
@@ -12,8 +12,13 @@ class VRMMQTTClient(VictronMQTTHub):
         vrm_id: str,
         port: int = 8883,
         use_ssl: bool = True,
+        update_frequency: int | None = None,
+        operation_mode: OperationMode = OperationMode.FULL,
     ):
         """Initialize VRM MQTT Client."""
+        # Safe update_frequency values between 0 and 300 seconds
+        if isinstance(update_frequency, int):
+            update_frequency = max(0, min(update_frequency, 300))
         super().__init__(
             host=host,
             username=username,
@@ -21,4 +26,6 @@ class VRMMQTTClient(VictronMQTTHub):
             port=port,
             use_ssl=use_ssl,
             installation_id=vrm_id,
+            update_frequency_seconds=update_frequency,
+            operation_mode=operation_mode,
         )

--- a/victron_vrm/mqtt.py
+++ b/victron_vrm/mqtt.py
@@ -15,10 +15,31 @@ class VRMMQTTClient(VictronMQTTHub):
         update_frequency: int | None = None,
         operation_mode: OperationMode = OperationMode.FULL,
     ):
-        """Initialize VRM MQTT Client."""
-        # Safe update_frequency values between 0 and 300 seconds
+        """Initialize a VRM MQTT client for a specific installation.
+
+        if update_frequency is not None:
+            if not isinstance(update_frequency, int):
+                raise TypeError("update_frequency must be an int or None")
+            host: MQTT broker hostname or IP address.
+            username: Username used to authenticate with the MQTT broker.
+            password: Password used to authenticate with the MQTT broker.
+            vrm_id: VRM installation identifier to subscribe/publish for.
+            port: TCP port of the MQTT broker. Defaults to ``8883``.
+            use_ssl: Whether to use SSL/TLS for the MQTT connection.
+                Defaults to ``True``.
+            update_frequency: Optional update frequency in seconds for
+                periodic updates. If provided, values are clamped between
+                0 and 3600 seconds. ``None`` (the default) lets the
+                underlying :class:`victron_mqtt.Hub` use its own default
+                update frequency.
+            operation_mode: Operation mode for the MQTT client, controlling
+                how data is fetched and published. Must be a member of
+                :class:`victron_mqtt.OperationMode`. Defaults to
+                :data:`OperationMode.FULL`.
+        """
+        # Safe update_frequency values between 0 and 3600 seconds
         if isinstance(update_frequency, int):
-            update_frequency = max(0, min(update_frequency, 300))
+            update_frequency = max(0, min(update_frequency, 3600))
         super().__init__(
             host=host,
             username=username,


### PR DESCRIPTION
This pull request adds support for configuring the MQTT client's update frequency and operation mode when creating a VRM MQTT client, providing more flexibility for users of the library. The changes also ensure that the update frequency is safely bounded between 0 and 300 seconds.

### MQTT Client Configuration Enhancements

* Added `update_frequency` and `operation_mode` parameters to both the `VRMMQTTClient` constructor and the `get_mqtt_client_for_installation` method in `client.py`, allowing callers to specify how often updates are received and the operational mode of the MQTT client. [[1]](diffhunk://#diff-ff44b3a2069a674baeadc9e5d622e4c37ef34892eecb450c0e64711efd9a7163R507-R515) [[2]](diffhunk://#diff-c7cfad716c99be2ae94773811bd48003b0fa217e9a0f2d7677079afea2635d3aR15-R30)
* Ensured the `update_frequency` value is clamped between 0 and 300 seconds for safety and reliability.
* Updated imports in `client.py` and `mqtt.py` to include the new `OperationMode` type from `victron_mqtt`, supporting the new parameter. [[1]](diffhunk://#diff-ff44b3a2069a674baeadc9e5d622e4c37ef34892eecb450c0e64711efd9a7163R12) [[2]](diffhunk://#diff-c7cfad716c99be2ae94773811bd48003b0fa217e9a0f2d7677079afea2635d3aL1-R1)
* Passed the new parameters (`update_frequency_seconds` and `operation_mode`) to the base `VictronMQTTHub` class in `VRMMQTTClient`, ensuring the configuration is applied at the hub level.